### PR TITLE
Update class-edd-multilingual.php

### DIFF
--- a/class-edd-multilingual.php
+++ b/class-edd-multilingual.php
@@ -69,7 +69,7 @@ class EDD_Multilingual {
 
 		// Add back the flags to downloads manager. NOTE: Not working when EDD FES is used.
 		add_filter( 'edd_download_columns', array(
-			new WPML_Custom_Columns( $wpdb, $sitepress ),
+			new WPML_Custom_Columns( $sitepress ),
 			'add_posts_management_column'
 		) );
 


### PR DESCRIPTION
We should not pass `$wpdb` to the `WPML_Custom_Columns` as it's was removed from the signature, since is not used anywhere.

This fixes this fatal error:

```
Fatal error: Uncaught TypeError: Argument 1 passed to WPML_Custom_Columns::__construct() must be an instance of SitePress, instance of wpdb given, called in /.../edd-multilingual/class-edd-multilingual.php on line 72 and defined in /.../sitepress-multilingual-cms/classes/menu-elements/class-wpml-custom-columns.php on line 19
```